### PR TITLE
feat: Initial release of RLC Cloud Repos Framework

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+layout python3
+
+source_env_if_exists .envrc-local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+name: CI
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        # Rocky 8 is on 3.6, Rocky 9 on 3.9. Plus some future proofing.
+        python-version: ["3.6", "3.9", "3.10", "3.11", "3.12", "3.13"]
+
+    runs-on: ubuntu-latest
+    container: python:${{ matrix.python-version }}
+
+    steps:
+      - name: Set up a comment for coverage output
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        uses: peter-evans/find-comment@v3
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Test summary
+
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip setuptools
+          make dev
+
+      - name: Run linters
+        # Only run linters on the highest Python version to avoid conflicts
+        if: matrix.python-version == '3.13'
+        run: |
+          make lint
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov --cov-report=html --cov-report=term-missing | tee coverage.txt
+
+          echo '# Test summary from ${{matrix.python-version}}' > tmp_comment.md
+          cat << EOF >> tmp_comment.md
+          <details>
+          <summary>Click to expand</summary>
+
+          \`\`\`
+
+          $(cat coverage.txt)
+
+          \`\`\`
+
+          </details>
+          EOF
+
+      # Only handle coverage reporting from Python 3.13 run
+      - name: Upload coverage report
+        if: matrix.python-version == '3.13'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: htmlcov
+          if-no-files-found: error
+
+      - name: Comment test output on PR
+        if: matrix.python-version == '3.13' && github.event_name == 'pull_request'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: tmp_comment.md
+          edit-mode: replace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    # Only run if the tag is on a commit that's part of the main branch
+    if: github.event.base_ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.6"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          make dev
+
+      - name: Verify tag version matches package version
+        run: |
+          # Get version using pkg_resources
+          PKG_VERSION=$(python -m rlc.cloud_repos 2>/dev/null)
+          # Extract tag version (remove 'v' prefix)
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: Tag version ($TAG_VERSION) does not match package version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Build distribution
+        run: |
+          make sdist
+          make dist
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            dist/*.tar.gz
+            dist/*.whl
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,16 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+%{buildroot}
+*.zip
+*.tar.gz
+*.rpm
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
+#*.spec
 
 # Installer logs
 pip-log.txt
@@ -169,3 +173,28 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Per PR-1
+# Configuration files for dev tools
+.flake8
+.pre-commit-config.yaml
+.pylintrc
+.editorconfig
+.envrc-local
+*.bak
+
+# RPM build artifacts (engineer suggestion)
+*.rpm
+*.srpm
+rpmbuild/
+mockbuild/
+
+# Local Testing:
+Makefile.local
+scripts.local
+
+
+# Replit
+.replit
+.cache
+.pythonlibs

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,12 @@
+specfile_path: dist/rpm/python3-rlc-cloud-repos.spec
+downstream_package_name: python3-rlc-cloud-repos
+upstream_package_name: rlc.cloud_repos
+upstream_ref: dev
+create_pr: false
+update_release: false
+
+actions:
+  post-upstream-clone: "true"  # This disables patch generation
+  create-archive:
+    - make sdist
+    - sh -c 'ls -1t dist/rlc.cloud-repos-*.tar.gz | head -n 1'

--- a/.replit
+++ b/.replit
@@ -1,0 +1,17 @@
+modules = ["python-3.8"]
+run = "pytest --cov --cov-report term-missing"
+[nix]
+channel = "stable-24_05"
+packages = ["libyaml"]
+
+[workflows]
+runButton = "Run Tests with coverage"
+
+[[workflows.workflow]]
+name = "Run Tests with coverage"
+mode = "sequential"
+author = 4915123
+
+[[workflows.workflow.tasks]]
+task = "shell.exec"
+args = "pytest --cov --cov-report term-missing"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-python.python"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "python.pythonPath": ".venv/bin/python",
+    "python.formatting.provider": "black",
+    "editor.formatOnSave": true,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports": "explicit"
+    },
+    "python.linting.enabled": true,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+        "--max-line-length=88"
+    ],
+    "python.sortImports.args": [
+        "--profile",
+        "black"
+    ],
+    "python.testing.pytestArgs": [],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "makefile.configureOnOpen": false
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,198 @@
+pipeline {
+    agent {
+        label 'rocky'
+    }
+
+    parameters {
+        string(name: 'DEPOT_RESOURCES_BRANCH', defaultValue: 'main', description: 'Branch of the depot-resources repository to use')
+        booleanParam(name: 'DRY_RUN', defaultValue: true, description: 'Run the transformation but do not create a PR')
+    }
+
+    environment {
+        GITHUB_ORG = "ctrliq"
+        GITHUB_REPO = "rlc-cloud-repos"
+        PR_BRANCH = "update-azure-mirrors-${BUILD_NUMBER}"
+        GITHUB_API = "https://api.github.com"
+    }
+
+    stages {
+        stage('Setup') {
+            steps {
+                cleanWs()
+                echo "Starting Azure mirrors update pipeline"
+                echo "Using depot-resources branch: ${params.DEPOT_RESOURCES_BRANCH}"
+            }
+        }
+
+        stage('Checkout Repositories') {
+            steps {
+                echo "Checking out repositories"
+
+                // Create directories for repositories
+                sh 'mkdir -p depot-resources rlc-cloud-repos'
+
+                dir('rlc-cloud-repos') {
+                    // Checkout the rlc-cloud-repos repository associated with this job
+                    checkout scm
+                }
+
+                dir('depot-resources') {
+                    // Checkout depot-resources repository using scmGit
+                    checkout([
+                        $class: 'GitSCM',
+                        branches: [[name: params.DEPOT_RESOURCES_BRANCH]],
+                        userRemoteConfigs: [[
+                            url: "https://github.com/${GITHUB_ORG}/depot-resources.git",
+                            credentialsId: 'cbfeccf2-984b-4ff8-b042-187b73e4d777'
+                        ]]
+                    ])
+                }
+            }
+        }
+
+        stage('Prepare Environment') {
+            steps {
+                echo "Preparing environment for transformation"
+
+                // Copy the azure.metadata.yaml file
+                sh 'cp depot-resources/azure.metadata.yaml rlc-cloud-repos/'
+
+                // Make sure Python and required packages are available
+                sh '''
+                    if ! command -v python3 &> /dev/null; then
+                        echo "Python3 is not installed"
+                        exit 1
+                    fi
+
+                    if ! python3 -c "import yaml" &> /dev/null; then
+                        echo "Installing PyYAML"
+                        pip3 install --user pyyaml
+                    fi
+                '''
+            }
+        }
+
+        stage('Transform Configuration') {
+            steps {
+                dir('rlc-cloud-repos') {
+                    echo "Running the transformation script"
+
+                    // Run the transformation script
+                    sh 'python3 transform_azure_mirrors.py > new-ciq-mirrors.yaml'
+                }
+            }
+        }
+
+        stage('Check for Changes') {
+            steps {
+                dir('rlc-cloud-repos') {
+                    script {
+                        // Compare files to detect changes
+                        def hasChanges = sh(
+                            script: 'diff -q new-ciq-mirrors.yaml src/rlc_cloud_repos/data/ciq-mirrors.yaml || true',
+                            returnStatus: true
+                        )
+
+                        // If diff returns 0, files are the same (no changes)
+                        // If diff returns 1, files are different (changes exist)
+                        if (hasChanges == 1) {
+                            echo "Changes detected in mirrors configuration"
+                            env.HAS_CHANGES = 'true'
+                        } else {
+                            echo "No changes detected in mirrors configuration"
+                            env.HAS_CHANGES = 'false'
+                        }
+                    }
+                }
+            }
+        }
+
+        stage('Create Pull Request') {
+            when {
+                allOf {
+                    expression { env.HAS_CHANGES == 'true' }
+                    expression { !params.DRY_RUN }
+                }
+            }
+            steps {
+                dir('rlc-cloud-repos') {
+                    echo "Creating pull request for the changes"
+
+                    // Set up git configuration
+                    sh '''
+                        git config user.name "Jenkins CI"
+                        git config user.email "jenkins@ctrliq.com"
+                    '''
+
+                    // Create a new branch
+                    sh "git checkout -b ${PR_BRANCH}"
+
+                    // Replace the file
+                    sh 'cp new-ciq-mirrors.yaml src/rlc_cloud_repos/data/ciq-mirrors.yaml'
+
+                    // Add and commit changes
+                    sh '''
+                        git add src/rlc_cloud_repos/data/ciq-mirrors.yaml
+                        git commit -m "Update Azure mirrors configuration from depot-resources"
+                    '''
+
+                    // Push changes and create PR using the same credentials as used for checkout
+                    withCredentials([
+                        usernamePassword(
+                            credentialsId: 'cbfeccf2-984b-4ff8-b042-187b73e4d777',
+                            passwordVariable: 'GITHUB_TOKEN',
+                            usernameVariable: 'GITHUB_USER'
+                        )
+                    ]) {
+                        // Push the branch
+                        sh """
+                            git push https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${GITHUB_ORG}/${GITHUB_REPO}.git ${PR_BRANCH}
+                        """
+
+                        // Create the PR using GitHub API
+                        sh """
+                            curl -X POST \
+                                -H "Authorization: token ${GITHUB_TOKEN}" \
+                                -H "Accept: application/vnd.github.v3+json" \
+                                ${GITHUB_API}/repos/${GITHUB_ORG}/${GITHUB_REPO}/pulls \
+                                -d '{
+                                    "title": "Update Azure mirrors configuration",
+                                    "body": "Automated update of Azure mirrors configuration from latest depot-resources metadata.",
+                                    "head": "${PR_BRANCH}",
+                                    "base": "main"
+                                }'
+                        """
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            echo "Pipeline completed"
+
+            script {
+                if (env.HAS_CHANGES == 'true') {
+                    if (params.DRY_RUN) {
+                        echo "Changes were detected, but no PR was created (dry run mode)"
+                    } else {
+                        echo "Changes were detected and a PR was created"
+                    }
+                } else {
+                    echo "No changes were detected in the Azure mirrors configuration"
+                }
+            }
+        }
+        success {
+            echo "Pipeline succeeded"
+        }
+        failure {
+            echo "Pipeline failed. Please check the logs for details."
+        }
+        cleanup {
+            cleanWs()
+        }
+    }
+}
+

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include data/*.yaml
+include config/*.cfg

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,106 @@
+VERSION := $(shell python -m 'rlc.cloud_repos' 2>/dev/null)
+$(info "VERSION: $(VERSION)")
+GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+PACKAGE := rlc.cloud-repos
+PY_PACKAGE := rlc.cloud_repos
+RPM_PACKAGE := python3-rlc-cloud-repos
+distdir := dist
+
+.PHONY: install clean test lint dist rpm spec dev mock
+
+$(distdir)/$(RPM_PACKAGE).spec: rpm/$(RPM_PACKAGE).spec.in
+	@echo "📄 Generating RPM spec file..."
+	@echo "  Version: $(VERSION)"
+	mkdir -p $(distdir)
+	sed -e 's/^\(Version:\s*\)VERSION/\1'$(VERSION)'/' rpm/$(RPM_PACKAGE).spec.in > $(distdir)/$(RPM_PACKAGE).spec
+
+spec: $(distdir)/$(RPM_PACKAGE).spec
+
+dev:
+	@echo "🔧 Installing development dependencies..."
+	pip install $(PIP_OPTIONS) -e .[dev]
+	pip install $(PIP_OPTIONS) -e ./framework[dev]
+
+install:
+	@echo "🔧 Installing $(PACKAGE) globally..."
+	pip install --root=/ --prefix=/usr -e .
+
+$(distdir)/$(PY_PACKAGE)-$(VERSION)-py3-none-any.whl: setup.cfg setup.py MANIFEST.in $(shell find cloud-repos -name '*.py') config/* data/*
+	@echo "🛞 Building wheel..."
+	python3 -m build --wheel
+
+dist: $(distdir)/$(PY_PACKAGE)-$(VERSION)-py3-none-any.whl
+
+$(distdir)/$(PACKAGE)-$(VERSION).tar.gz: setup.cfg setup.py MANIFEST.in $(shell find cloud-repos -name '*.py') config/* data/*
+	@echo "📦 Building source distribution..."
+	python3 -m build --sdist
+
+sdist: $(distdir)/$(PACKAGE)-$(VERSION).tar.gz
+
+lint:
+	@echo "🔍 Running linters..."
+	black --check cloud-repos framework tests
+	isort --check-only cloud-repos framework tests
+	flake8 cloud-repos framework tests
+
+clean:
+	@echo "🦚 Cleaning build artifacts..."
+	# rm -f rpm/$(RPM_PACKAGE).spec rpm/*.tar.gz
+	rm -rf build dist framework/build framework/dist
+	rm -rf rpm/[0-9]*.patch
+	find ./ -type d -name "*.egg-info" -exec rm -rf {} +
+	find ./ -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type d -name "*.dist-info" -exec rm -rf {} +
+	find . -type d -name "*.egg-info" -exec rm -rf {} +
+	find . -type f -name "*.orig" -exec rm -f {} +
+	find . -type f -name "*.rej" -exec rm -f {} +
+	rm -rf ~/.cache/pip/wheels/*
+	rm -f .coverage
+
+rpm: spec sdist
+	@echo "📄 Copying tarball into SOURCES for rpmbuild..."
+	mkdir -p ~/rpmbuild/SOURCES
+	cp dist/$(PACKAGE)-$(VERSION).tar.gz ~/rpmbuild/SOURCES/
+
+	@echo "🚰 Running rpmbuild..."
+	if ! rpmbuild -ba $(distdir)/$(RPM_PACKAGE).spec; then \
+		echo "💥 RPM build failed. Ensure BuildRequires includes pyproject macros or fallback to pip install."; \
+		exit 1; \
+	fi
+
+mock: spec sdist
+	@echo "📦 Building SRPM..."
+	mkdir -p $(distdir)/rpm
+	cp dist/$(RPM_PACKAGE).spec $(distdir)/rpm/
+	cp dist/$(PACKAGE)-$(VERSION).tar.gz $(distdir)/rpm/
+	# Run packit with current branch
+	packit --debug srpm --output dist/ --upstream-ref $(GIT_BRANCH)
+	@echo "🧪 Running mock build..."
+	mock -r rocky-9-x86_64 --resultdir=dist --enable-network dist/*.src.rpm
+
+# Testing
+PYTHON ?= python3
+PYTHONPATH := src
+PYTHON_VERSION ?= 3.11
+
+.PHONY: test test-coverage test-podman
+
+test-podman:
+	@echo "🐋 Running tests in Podman container with Python $(PYTHON_VERSION)..."
+	podman pull docker.io/library/python:$(PYTHON_VERSION)
+	podman run --rm -v .:/app:Z -w /app python:$(PYTHON_VERSION) bash -c \
+		"python -m pip install --upgrade pip setuptools && make dev && python -m pytest --cov --cov-report=term-missing"
+
+test:
+	@echo "🧪 Running test suite with pytest..."
+	@PYTHONPATH=$(PYTHONPATH) $(PYTHON) -m pytest -v tests --cov --cov-report=term-missing
+
+test-coverage:
+	pytest --cov --cov-report=term-missing
+
+all: clean rpm publish clean
+
+# Include local overrides
+-include Makefile.local
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,172 @@
+# RLC Cloud Repos - Cloud-Agnostic Repository Auto-Configuration
+
+## Overview
+
+**RLC Cloud Repos** is a **cloud-init-powered, cloud-agnostic** repository configuration utility designed to:
+
+- Automatically **configure DNF/YUM repositories** for Rocky Linux by CIQ (RLC) instances in the Cloud.
+- **Dynamically select the best repository mirror** based on cloud provider and region.
+- **Integrate with Cloud-Init**, ensuring repo configuration happens early in the boot process.
+- **Deploy updates via RPM packaging**, making it easy to manage at scale.
+
+## Problem Statement
+
+Deploying and Running Rocky Linux on multiple cloud providers (AWS, Azure, GCP, OCI) requires custom repository configuration:
+
+- Mirrors vary per provider and region.
+- Network performance and bandwidth metering demand regional proximity.
+- Instance metadata varies widely.
+- Fallbacks when a mirror is unavailable (e.g., AWS instances in `us-west-1` fallback to `us-east-1`).
+- Ensuring Cloud-Init properly integrates the repository configurations during instance boot.
+
+## Key Benefits
+
+1. **Zero-Touch Configuration** – Just boot the VM and it configures itself.
+2. **Performance-Aware** – Selects pre-configured available mirror.
+3. **Cloud-Native** – Leverages `cloud-init query`, not hand-coded API logic.
+4. **Dynamic and Safe** – Uses a marker file to prevent reconfig unless explicitly allowed or on package update.
+
+---
+
+## **Architecture**
+
+The system is designed as **modular components** that work together to **detect cloud provider, determine region, configure repositories, and integrate with Cloud-Init**.
+
+### **System Flow**
+
+```ascii
++----------------------------+
+|     Instance Boot          |
++----------------------------+
+           |
+           v
++--------------------------------+
+| Detect Cloud Provider & Region |
+| via cloud-init                 |
++--------------------------------+
+           |
+           v
++----------------------------+
+| Select Primary + Backup    |
+| Mirrors from region map    |
++----------------------------+
+           |
+           v
++----------------------------+
+| Configure DNF Variables    |
+| in /etc/dnf/vars/          |
++----------------------------+
+           |
+           v
++----------------------------+
+| Touch marker file to skip  |
+| reconfiguration next boot  |
++----------------------------+
+```
+
+---
+
+## Core Components
+
+### ☁️ `cloud_metadata.py`
+
+- Uses `cloud-init query` to fetch:
+  - Provider name
+  - Region
+- Exits early with an error if cloud-init query fails or is unavailable.
+
+### 📦 `repo_config.py`
+
+- Generates DNF Variables from cloud-init metadata.
+- Supports:
+  - Primary mirror
+  - Backup mirror
+  - Region
+- Maps variables against `ciq-mirrors.yaml` matrix
+- CasC (Configuration As Code) Versioned.
+  - No code changes required for _any_ mirror changes.
+
+### 🧠 `main.py`
+
+- Entry point triggered by cloud-init or manual run.
+- Checks for marker file to skip duplicate configuration.
+- Writes a marker file once run to prevent recurrent reconfiguring at reboot.
+
+---
+
+## Installation & Usage
+
+### 📦 Build Source Distribution
+
+To generate the source tarball used for packaging:
+
+```bash
+make sdist
+```
+
+This will produce a `.tar.gz` source archive in the `dist/` directory, suitable for consumption by downstream RPM packaging workflows.
+
+---
+
+### 🚀 Manually Trigger Repository Configuration
+
+```bash
+rlc-cloud-repos
+```
+
+This will:
+
+- Detect cloud metadata using `cloud-init query`
+- Write marker file to skip reconfig on next boot
+
+---
+
+## Supported Cloud Providers
+
+The following providers are supported natively via `cloud-init` metadata detection:
+
+- **AWS**
+- **Azure**
+- **Google Cloud Platform (GCP)**
+- **Oracle Cloud Infrastructure (OCI)**
+
+Mirror mapping is handled via a region → mirror YAML file (`ciq-mirrors.yaml`) shipped in the package.
+
+---
+
+## Configuration
+
+- Mirror selection logic is data-driven via `ciq-mirrors.yaml`
+- Configuration persists indefinitely until removed/updated.
+
+---
+
+## Development Notes
+
+- Touch file at `/etc/rlc-cloud-repos/.configured` used to block rerun
+- Logs only to stdout/stderr
+- The included RPM spec (rpm/python3-rlc-cloud-repos.spec) handles the marker file lifecycle:
+  1. Creates the marker file on initial install (%post).
+  2. Removes the marker file on upgrade (%posttrans) and uninstall (%postun) to allow reconfiguration.
+
+---
+
+## 🧠 Development Notes
+
+### 🔀 Current Development Branch
+
+Create branches off of `git@github.com:ctrliq/rlc-cloud-repos.git Branch: main`
+to develop PRs.
+
+---
+
+## **License**
+
+**RLC Cloud Repos** is licensed under the **MIT License**.
+
+---
+
+## **Authors**
+
+**CIQ Solutions Delivery Engineering Team**
+[https://github.com/ctrliq/rlc-cloud-repos](https://github.com/ctrliq/rlc-cloud-repos)

--- a/cloud-repos/rlc/cloud_repos/__init__.py
+++ b/cloud-repos/rlc/cloud_repos/__init__.py
@@ -1,0 +1,13 @@
+try:
+    # Try importlib.metadata first (available in Python 3.8+)
+    from importlib.metadata import version
+
+    __version__ = version("rlc.cloud-repos")
+except ImportError:  # pragma: no cover
+    try:
+        # Fallback to pkg_resources
+        from pkg_resources import get_distribution
+
+        __version__ = get_distribution("rlc.cloud-repos").version
+    except Exception:  # pragma: no cover
+        __version__ = "unknown"

--- a/cloud-repos/rlc/cloud_repos/__main__.py
+++ b/cloud-repos/rlc/cloud_repos/__main__.py
@@ -1,0 +1,9 @@
+from rlc.cloud_repos import __version__
+
+
+def main():  # pragma: no cover
+    print(__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/cloud-repos/rlc/cloud_repos/cloud_metadata.py
+++ b/cloud-repos/rlc/cloud_repos/cloud_metadata.py
@@ -1,0 +1,35 @@
+# src/rlc_cloud_repos/cloud_metadata.py
+"""
+RLC Cloud Repos - Cloud Metadata Detection
+
+Extracts normalized cloud provider and region from cloud-init query.
+"""
+
+import logging
+import subprocess
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+
+def get_cloud_metadata() -> Dict[str, str]:
+    """
+    Detects the cloud environment using cloud-init's query tool.
+
+    Returns:
+        dict[str, str]: Dictionary with keys 'provider' and 'region'
+
+    Raises:
+        RuntimeError: If cloud-init query fails.
+    """
+    try:
+        provider = subprocess.check_output(
+            ["cloud-init", "query", "cloud_name"], text=True
+        ).strip()
+        region = subprocess.check_output(
+            ["cloud-init", "query", "region"], text=True
+        ).strip()
+        return {"provider": provider, "region": region}
+    except subprocess.CalledProcessError as e:
+        logger.error("Failed to query cloud-init: %s", e)
+        raise RuntimeError("cloud-init must be available and functional")

--- a/cloud-repos/rlc/cloud_repos/dnf_vars.py
+++ b/cloud-repos/rlc/cloud_repos/dnf_vars.py
@@ -1,0 +1,75 @@
+"""
+DNF Variable Management for CIQ Cloud Repos
+
+This module sets DNF variables in /etc/dnf/vars required for proper repository
+URL construction using system and cloud metadata.
+
+Variables Managed:
+- baseurl1: Primary mirror URL
+- baseurl2: Global fallback mirror
+- region: Cloud region
+"""
+
+import logging
+from pathlib import Path
+
+BACKUP_SUFFIX = ".bak"
+
+logger = logging.getLogger(__name__)
+
+
+def _write_dnf_var(basepath: Path, name: str, value: str):
+    """
+    Creates or updates a DNF variable file with a given value.
+
+    - If the file does not exist, it is created with the specified value.
+    - If the file exists and contains a different value, it is backed up
+      (appending '.bak') before being overwritten.
+    - If the file already contains the desired value, no action is taken.
+
+    Args:
+        name (str): Name of the DNF variable (e.g., 'region', 'baseurl1').
+        value (str): Value to set for the DNF variable.
+
+    Side Effects:
+        - Writes to /etc/dnf/vars/
+        - Creates .bak files for existing values that are changed
+        - Logs all operations
+    """
+    path = basepath / name
+
+    # Ensure /etc/dnf/vars exists
+    basepath.mkdir(parents=True, exist_ok=True)
+
+    # Check if exists and content differs
+    if path.exists():
+        current_value = path.read_text().strip()
+        if current_value == value:
+            logger.debug(f"DNF var '{name}' already set correctly.")
+            return
+        # Backup
+        try:
+            backup_path = path.with_suffix(path.suffix + BACKUP_SUFFIX)
+            path.rename(backup_path)
+            logger.info(f"Backed up existing DNF var '{name}' to '{backup_path.name}'")
+        except Exception as e:
+            logger.error(f"Cannot backup DNF var '{name}' ({e}), skipping")
+            # return
+
+    try:
+        path.write_text(f"{value}\n")
+        logger.info(f"Wrote DNF var '{name}': {value}")
+    except Exception as e:
+        logger.error(f"Cannot write to DNF var '{name}' ({e}), skipping")
+
+
+def ensure_all_dnf_vars(basepath: Path, primary_url: str, backup_url: str):
+    """
+    Sets DNF variables for the primary and backup mirror URLs.
+
+    Args:
+        primary_url (str): Preferred mirror.
+        backup_url (str): Fallback mirror.
+    """
+    _write_dnf_var(basepath, "baseurl1", primary_url)
+    _write_dnf_var(basepath, "baseurl2", backup_url)

--- a/cloud-repos/rlc/cloud_repos/log_utils.py
+++ b/cloud-repos/rlc/cloud_repos/log_utils.py
@@ -1,0 +1,48 @@
+# src/rlc_cloud_repos/log_utils.py
+"""
+Logging utility for cloud-init-friendly stdout/stderr output.
+
+Provides: log_and_print()
+"""
+
+import logging
+import sys
+
+logger = logging.getLogger("rlc-cloud-repos")
+
+
+def log_and_print(msg: str, level: str = "info") -> None:
+    """
+    Logs a message and prints it to stdout or stderr depending on level.
+
+    Args:
+        msg (str): The message to emit.
+        level (str): One of 'info', 'warn', 'error'. Default is 'info'.
+    """
+    if level == "info":
+        logger.info(msg)
+        print(msg)
+    elif level in ("warn", "warning"):
+        logger.warning(msg)
+        print(f"⚠️ {msg}")
+    elif level == "error":
+        logger.error(msg)
+        print(f"❌ {msg}", file=sys.stderr)
+
+
+def setup_logging(debug: bool = False) -> None:
+    """
+    Configure logging to emit to stdout/stderr only.
+
+    This aligns with cloud-init expectations (no syslog).
+    """
+    logger.setLevel(logging.DEBUG if debug else logging.INFO)
+
+    # Avoid adding duplicate handlers
+    if logger.hasHandlers():
+        return
+
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setLevel(logging.DEBUG if debug else logging.INFO)
+    stream_handler.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    logger.addHandler(stream_handler)

--- a/cloud-repos/rlc/cloud_repos/main.py
+++ b/cloud-repos/rlc/cloud_repos/main.py
@@ -1,0 +1,130 @@
+#!env python
+"""
+RLC Cloud Repo Resolver CLI
+
+This tool detects the cloud provider and region via cloud-init,
+selects the appropriate CIQ repository mirror, and writes DNF vars
+for optimized regional repo access.
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+from rlc.cloud_repos import __version__ as rlc_version
+from rlc.cloud_repos.cloud_metadata import get_cloud_metadata
+from rlc.cloud_repos.dnf_vars import ensure_all_dnf_vars
+from rlc.cloud_repos.log_utils import log_and_print, logger, setup_logging
+from rlc.cloud_repos.repo_config import load_mirror_map, select_mirror
+
+MARKERFILE = "/etc/rlc-cloud-repos/.configured"
+DEFAULT_MIRROR_PATH = "/usr/share/rlc-cloud-repos/ciq-mirrors.yaml"
+DNF_VARS_DIR = "/etc/dnf/vars"
+
+
+def check_touchfile() -> bool:
+    """
+    Check if the system has already been configured.
+    Returns True if marker file exists, indicating configuration should be skipped.
+
+    Returns:
+        bool: True if marker file exists, False otherwise
+    """
+    if os.path.exists(MARKERFILE):
+        log_and_print(f"Marker file exists ({MARKERFILE}). Skipping repo update.")
+        return True
+    return False
+
+
+def write_touchfile() -> None:
+    """
+    Create a touchfile to indicate configuration was completed.
+    Prevents automatic reruns on reboot (cloud-init idempotency).
+    """
+    os.makedirs(os.path.dirname(MARKERFILE), exist_ok=True)
+    with open(MARKERFILE, "w") as f:
+        f.write(f"Configured on {datetime.now().isoformat()}\n")
+
+
+def _configure_repos(mirror_file_path: str) -> None:
+    """
+    Core logic for detecting metadata, selecting mirrors, and configuring DNF vars.
+    """
+    # Detect provider + region via cloud-init query
+    metadata = get_cloud_metadata()
+    provider = metadata["provider"]
+    region = metadata["region"]
+    log_and_print(f"Using cloud metadata: provider={provider}, region={region}")
+
+    # Load mirror map + resolve appropriate URL
+    mirror_map = load_mirror_map(mirror_file_path)
+    log_and_print(f"Loaded mirror map from {mirror_file_path}")
+
+    primary_url, backup_url = select_mirror(
+        {"provider": provider, "region": region}, mirror_map
+    )
+    log_and_print(f"Selected mirror URL: {primary_url}")
+
+    # Set DNF vars
+    ensure_all_dnf_vars(DNF_VARS_DIR, primary_url, backup_url)
+    logger.info("DNF vars set for mirror=%s and backup=%s", primary_url, backup_url)
+
+    # Create marker file to prevent future reruns
+    write_touchfile()
+    log_and_print(f"Marker file written to {MARKERFILE}")
+
+
+def parse_args(args=None):
+    """
+    Parse command line arguments
+
+    Args:
+        args: Command line arguments (defaults to None, which uses sys.argv[1:])
+
+    Returns:
+        Parsed arguments namespace
+    """
+    parser = argparse.ArgumentParser(
+        description="RLC Cloud Repo Resolver version %s" % rlc_version,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument("--mirror-file", help="Override path to mirror map YAML")
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Force reconfiguration (ignore marker file)",
+    )
+    return parser.parse_args(args)
+
+
+def main(args=None) -> int:
+    """
+    Entry point for RLC cloud repo resolver. Handles argument parsing and
+    calls the core configuration logic.
+
+    Args:
+        args: Command line arguments (defaults to None, which uses sys.argv[1:])
+
+    Returns:
+        int: 0 for success, 1 for failure
+    """
+    setup_logging()
+
+    parsed_args = parse_args(args)
+
+    if not parsed_args.force:
+        if check_touchfile():  # Skip configuration if marker file exists
+            return 0
+
+    mirror_path = parsed_args.mirror_file or DEFAULT_MIRROR_PATH
+    try:
+        _configure_repos(mirror_path)
+        return 0
+    except Exception as e:
+        logger.error("Configuration failed: %s", e, exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))  # pragma: no cover.git

--- a/cloud-repos/rlc/cloud_repos/repo_config.py
+++ b/cloud-repos/rlc/cloud_repos/repo_config.py
@@ -1,0 +1,82 @@
+# src/rlc_cloud_repos/repo_config.py
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+import yaml
+
+from rlc.cloud_repos.log_utils import log_and_print
+
+
+def load_mirror_map(yaml_path: str) -> Dict[str, Any]:
+    """
+    Loads the YAML mirror map config.
+
+    Args:
+        yaml_path (str): Path to YAML config.
+
+    Returns:
+        Dict[str, Any]: Mirror map dictionary.
+
+    Raises:
+        FileNotFoundError: If file does not exist.
+        ValueError: If YAML is invalid.
+    """
+    path = Path(yaml_path)
+
+    if not path.exists():
+        log_and_print(f"Mirror YAML not found at {yaml_path}", level="error")
+        raise FileNotFoundError(f"Mirror config YAML not found at {yaml_path}")
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        log_and_print("YAML parsing error", level="error")
+        raise ValueError(f"Invalid YAML in mirror map: {e}")
+
+
+def select_mirror(
+    metadata: Dict[str, str], mirror_map: Dict[str, Any]
+) -> Tuple[str, str]:
+    """
+    Chooses the best primary and backup mirror URLs for the given cloud metadata.
+
+    Returns:
+        tuple[str, str]: (primary_url, backup_url)
+    """
+    provider = metadata["provider"].lower()
+    region = metadata["region"]
+
+    # Set up our fallback fallbacks We do not use default values here because we want this to fail in tests if we have a
+    # bad file. We must always have a default with primary and backup values set.
+    try:
+        default_primary = mirror_map["default"]["primary"]
+        default_backup = mirror_map["default"]["backup"]
+    except KeyError as e:
+        log_and_print(f"Missing default mirror values: {e}", level="error")
+        raise ValueError(
+            "Mirror map must have a default entry with primary and backup values set."
+        )
+
+    log_and_print(
+        f"Selecting mirror for provider={provider}, region={region}", level="info"
+    )
+
+    if provider in mirror_map:
+        # The provider was located in the mirror map
+        provider_map = mirror_map[provider]
+        if region in provider_map:
+            # the region was located in the provider map
+            region_map = provider_map.get(region, {})
+        else:
+            # the region was not located in the provider map, use the default for the provider
+            region_map = provider_map.get("default", {})
+        return region_map.get("primary", default_primary), region_map.get(
+            "backup", default_backup
+        )
+
+    else:
+        log_and_print(
+            f"Provider {provider} not found, using default values", level="info"
+        )
+        return default_primary, default_backup

--- a/config/20_rlc-cloud-repos.cfg
+++ b/config/20_rlc-cloud-repos.cfg
@@ -1,0 +1,5 @@
+# Trigger CIQ repo configuration on first boot
+#   || on user invocation with overrides
+#   || on rpm update needing reconfiguration
+bootcmd:
+  - [ rlc-cloud-repos ]

--- a/data/ciq-mirrors.yaml
+++ b/data/ciq-mirrors.yaml
@@ -1,0 +1,133 @@
+aws:
+  us-east-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.us-east-1.prod.ciqws.com
+  us-east-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.us-east-2.prod.ciqws.com
+  us-west-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.us-west-1.prod.ciqws.com
+  us-west-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.us-west-2.prod.ciqws.com
+  af-south-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.af-south-1.prod.ciqws.com
+  ap-east-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-east-1.prod.ciqws.com
+  ap-south-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-south-1.prod.ciqws.com
+  ap-south-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-south-2.prod.ciqws.com
+  ap-northeast-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-northeast-1.prod.ciqws.com
+  ap-northeast-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-northeast-2.prod.ciqws.com
+  ap-northeast-3:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-northeast-3.prod.ciqws.com
+  ap-southeast-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-1.prod.ciqws.com
+  ap-southeast-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-2.prod.ciqws.com
+  ap-southeast-3:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-3.prod.ciqws.com
+  ap-southeast-4:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-4.prod.ciqws.com
+  ap-southeast-5:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-5.prod.ciqws.com
+  ap-southeast-7:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ap-southeast-7.prod.ciqws.com
+  ca-central-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ca-central-1.prod.ciqws.com
+  ca-west-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.ca-west-1.prod.ciqws.com
+  eu-central-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-central-1.prod.ciqws.com
+  eu-central-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-central-2.prod.ciqws.com
+  eu-north-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-north-1.prod.ciqws.com
+  eu-west-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-west-1.prod.ciqws.com
+  eu-west-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-west-2.prod.ciqws.com
+  eu-west-3:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-west-3.prod.ciqws.com
+  eu-south-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-south-1.prod.ciqws.com
+  eu-south-2:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.eu-south-2.prod.ciqws.com
+  il-central-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.il-central-1.prod.ciqws.com
+  mx-central-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.mx-central-1.prod.ciqws.com
+  me-south-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.me-south-1.prod.ciqws.com
+  me-central-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.me-central-1.prod.ciqws.com
+  sa-east-1:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.sa-east-1.prod.ciqws.com
+  default:
+    primary: https://depot.prod.ciqws.com
+    backup: https://depot.us-east-1.prod.ciqws.com
+    
+azure:
+  eastus: &azure_eastus
+    primary: https://depot.eastus.prod.azure.ciq.com
+    backup: https://depot.westus2.prod.azure.ciq.com
+
+  australiaeast:
+    primary: https://depot.australiaeast.prod.azure.ciq.com
+    backup: https://depot.southeastasia.prod.azure.ciq.com
+
+  northeurope:
+    primary: https://depot.northeurope.prod.azure.ciq.com
+    backup: https://depot.southeastasia.prod.azure.ciq.com
+
+  southeastasia:
+    primary: https://depot.southeastasia.prod.azure.ciq.com
+    backup: https://depot.northeurope.prod.azure.ciq.com
+
+  westus2:
+    primary: https://depot.westus2.prod.azure.ciq.com
+    backup: https://depot.eastus.prod.azure.ciq.com
+
+  default: *azure_eastus
+
+gcp:
+  default: *azure_eastus
+
+oracle:
+  default:
+    primary: https://oracle.depot.ciq.com
+    backup: https://depot.eastus.azure.ciq.com
+
+default: *azure_eastus

--- a/framework/rlc_cloud_repos_framework/azure_mirrors.py
+++ b/framework/rlc_cloud_repos_framework/azure_mirrors.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+
+import sys
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+try:
+    import configargparse
+except ImportError:  # pragma: no cover
+    print("Error: configargparse is required. Install with: pip -e install framework")
+    sys.exit(1)
+
+
+def load_yaml_file(file_path: str) -> Dict[str, Any]:
+    """Load YAML file and return parsed data.
+
+    Args:
+        file_path: Path to the YAML file to load
+
+    Returns:
+        Parsed YAML data as dictionary
+    """
+    with open(file_path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def extract_active_regions(metadata: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Extract active (non-commented) regions from Azure metadata.
+
+    Args:
+        metadata: Parsed Azure metadata YAML
+
+    Returns:
+        List of active regions with their names and pairs
+    """
+    active_regions = []
+    for region in metadata.get("Regions", []):
+        # Skip commented out regions (they won't be in the list)
+        if region and "name" in region:
+            active_regions.append(
+                {
+                    "name": region["name"],
+                    "regional_pair": region.get("regional_pair", ""),
+                }
+            )
+    return active_regions
+
+
+def generate_mirror_urls(regions: List[Dict[str, str]]) -> Dict[str, Dict[str, str]]:
+    """Generate mirror URLs for each active region.
+
+    Args:
+        regions: List of regions with their names and pairs
+
+    Returns:
+        Dictionary of region names mapped to primary and backup URLs
+    """
+    mirrors = {}
+    for region in regions:
+        name = region["name"]
+        pair = region["regional_pair"]
+
+        mirrors[name] = {
+            "primary": f"https://depot.{name}.prod.azure.ciq.com",
+            "backup": f"https://depot.{pair}.prod.azure.ciq.com",
+        }
+    return mirrors
+
+
+def preserve_default_entry(existing_mirrors: Dict[str, Any]) -> Dict[str, str]:
+    """Extract the default entry from existing mirrors.
+
+    Args:
+        existing_mirrors: Existing mirrors configuration
+
+    Returns:
+        Default mirror configuration
+    """
+    return existing_mirrors["azure"]["default"]
+
+
+def transform_azure_mirrors(
+    metadata_path: str, mirrors_path: str, output_path: Optional[str] = None
+) -> Dict[str, Any]:
+    """Transform Azure metadata to mirror format.
+
+    Args:
+        metadata_path: Path to the Azure metadata YAML file
+        mirrors_path: Path to the existing mirrors YAML file
+        output_path: Optional path to write the transformed YAML
+
+    Returns:
+        Updated mirrors configuration
+    """
+    # Load YAML files
+    azure_metadata = load_yaml_file(metadata_path)
+    ciq_mirrors = load_yaml_file(mirrors_path)
+
+    # Extract active regions and their pairs
+    active_regions = extract_active_regions(azure_metadata)
+
+    # Generate mirror URLs
+    azure_mirrors = generate_mirror_urls(active_regions)
+
+    # Preserve default entry
+    azure_mirrors["default"] = preserve_default_entry(ciq_mirrors)
+
+    # Create the new azure section
+    new_ciq_mirrors = ciq_mirrors.copy()
+    new_ciq_mirrors["azure"] = azure_mirrors
+
+    # Write to output file if specified
+    if output_path:
+        with open(output_path, "w") as f:
+            yaml.dump(new_ciq_mirrors, f, default_flow_style=False)
+
+    return new_ciq_mirrors
+
+
+def parse_args(args=None):
+    """Parse command line arguments with configargparse.
+
+    Args:
+        args: Command line arguments (uses sys.argv if None)
+
+    Returns:
+        Parsed arguments
+    """
+    parser = configargparse.ArgumentParser(
+        description="Transform Azure metadata to mirror format.",
+        default_config_files=[
+            "~/.config/rlc-azure-mirrors.conf",
+            "/etc/rlc-azure-mirrors.conf",
+        ],
+        config_file_parser_class=configargparse.YAMLConfigFileParser,
+    )
+
+    parser.add_argument(
+        "-c",
+        "--config",
+        is_config_file=True,
+        help="Config file path (can also use ~/.config/rlc-azure-mirrors.conf or /etc/rlc-azure-mirrors.conf)",
+    )
+
+    parser.add_argument(
+        "--metadata",
+        env_var="AZURE_METADATA_PATH",
+        default="azure.metadata.yaml",
+        help="Path to the Azure metadata YAML file (default: azure.metadata.yaml)",
+    )
+
+    parser.add_argument(
+        "--mirrors",
+        env_var="CIQ_MIRRORS_PATH",
+        default="src/rlc_cloud_repos/data/ciq-mirrors.yaml",
+        help="Path to the existing mirrors YAML file (default: src/rlc_cloud_repos/data/ciq-mirrors.yaml)",
+    )
+
+    parser.add_argument(
+        "--output",
+        env_var="OUTPUT_PATH",
+        help="Path to write the transformed YAML (default: stdout)",
+    )
+
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        env_var="VERIFY_ONLY",
+        help="Verify only, report if changes would be made (no output)",
+    )
+
+    return parser.parse_args(args)
+
+
+def main(args=None):
+    """Main entry point for the script.
+
+    Args:
+        args: Command line arguments (uses sys.argv if None)
+
+    Returns:
+        Exit code (0 for success, non-zero for error)
+    """
+    try:
+        parsed_args = parse_args(args)
+
+        # Transform the Azure mirrors
+        new_mirrors = transform_azure_mirrors(
+            parsed_args.metadata,
+            parsed_args.mirrors,
+            parsed_args.output if not parsed_args.verify else None,
+        )
+
+        # If verify mode, check if there are changes
+        if parsed_args.verify:
+            existing_mirrors = load_yaml_file(parsed_args.mirrors)
+            if new_mirrors["azure"] != existing_mirrors["azure"]:
+                print("Changes detected in Azure mirrors configuration.")
+                return 1
+            else:
+                print("No changes detected in Azure mirrors configuration.")
+                return 0
+
+        # If no output file specified, print to stdout
+        if not parsed_args.output:
+            print(yaml.dump(new_mirrors, default_flow_style=False))
+
+        return 0
+
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())  # pragma: no cover

--- a/framework/setup.cfg
+++ b/framework/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = rlc-cloud-repos-framework
+version = 0.1.0
+description = Framework components for RLC Cloud Repos
+long_description = Framework library for configuring RLC cloud repositories
+author = CIQ Linux Engineering
+author_email = support@ciq.com
+license = MIT
+url = https://github.com/ctrliq/rlc-cloud-repos
+
+[options]
+packages = find_namespace:
+package_dir =
+    = .
+python_requires = >=3.6,<3.14
+include_package_data = true
+install_requires =
+    rlc.cloud-repos
+    PyYAML
+    configargparse
+
+[options.packages.find]
+where = .
+include = rlc_cloud_repos_framework*
+
+[options.extras_require]
+dev =
+    pytest>=7.0.0
+    pytest-cov>=4.0.0
+
+[pip]
+editable-mode = compat

--- a/framework/setup.py
+++ b/framework/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/rpm/python3-rlc-cloud-repos.spec.in
+++ b/rpm/python3-rlc-cloud-repos.spec.in
@@ -1,0 +1,65 @@
+%global pypi_name rlc.cloud-repos
+%global rpm_name rlc-cloud-repos
+Name:           python3-%{rpm_name}
+Version:        VERSION
+Release:        1%{?dist}
+Summary:        A cloud-init querying and repository configuration tool for Rocky Linux from CIQ Products (RLC)
+
+License:        MIT
+URL:            https://ciq.com/
+Source0:        %{pypi_name}-%{version}.tar.gz
+
+BuildArch:      noarch
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-devel
+BuildRequires:  python3-pip
+BuildRequires:  python3-wheel
+BuildRequires:  pyproject-rpm-macros
+
+Requires:       python3
+Requires:       python3-pyyaml
+Requires:       cloud-init
+
+%description
+Installs a utility plus cloud-init configuration to run the utility on first and every boot to check the instance metadata and update the RLC RPM repositories to point to the appropriate source.
+
+%prep
+%setup -q -n %{pypi_name}-%{version}
+
+%build
+%pyproject_wheel
+
+%install
+%pyproject_install
+rm %{buildroot}%{_prefix}/config/20_rlc-cloud-repos.cfg
+rm %{buildroot}%{_prefix}/data/ciq-mirrors.yaml
+install -Dm0644 config/20_rlc-cloud-repos.cfg %{buildroot}/etc/cloud/cloud.cfg.d/20_rlc-cloud-repos.cfg
+install -Dm0644 data/ciq-mirrors.yaml %{buildroot}/usr/share/rlc-cloud-repos/ciq-mirrors.yaml
+
+%files
+%license LICENSE
+%doc README.md
+
+# CLI entrypoint (console script)
+%{_bindir}/rlc-cloud-repos
+
+# Python package content
+%{python3_sitelib}/rlc/
+%{python3_sitelib}/rlc.cloud_repos*.dist-info
+
+# Config and static data
+%config(noreplace) /etc/cloud/cloud.cfg.d/20_rlc-cloud-repos.cfg
+/usr/share/rlc-cloud-repos/ciq-mirrors.yaml
+
+%post
+touch /etc/rlc-cloud-repos/.configured
+
+%postun
+rm -f /etc/rlc-cloud-repos/.configured
+
+%posttrans
+rm -f /etc/rlc-cloud-repos/.configured
+
+%changelog
+* Mon Mar 31 2025 Joel Hanger <jhanger@ciq.com> - 0.1.0-1
+- Initial version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,58 @@
+[metadata]
+name = rlc.cloud-repos
+version = 0.1.0
+description = A cloud-init querying and repository configuration tool for Rocky Linux from CIQ Products (RLC)
+long_description = file: README.md
+author = CIQ Linux Engineering
+author_email = support@ciq.com
+license = MIT
+url = https://github.com/ctrliq/rlc-cloud-repos
+
+[options]
+packages = find_namespace:
+package_dir =
+    = cloud-repos
+python_requires = >=3.6,<3.14
+include_package_data = true
+install_requires =
+    PyYAML
+
+[options.data_files]
+config =
+    config/20_rlc-cloud-repos.cfg
+data =
+    data/ciq-mirrors.yaml
+
+[options.packages.find]
+where = cloud-repos
+include = rlc*
+
+[options.entry_points]
+console_scripts =
+    rlc-cloud-repos = rlc.cloud_repos.main:main
+
+[options.extras_require]
+dev =
+    pytest>=7.0.0
+    pytest-cov>=4.0.0
+    flake8
+    isort
+    black
+    build>=0.9.0
+    setuptools>=40.6.0
+
+[tool:black]
+line-length = 120
+
+[tool:isort]
+# Directories to be sorted by isort
+src_paths = cloud-repos, framework, tests
+skip = ./.cache
+py_version = 36
+line_length = 120
+
+[pip]
+editable-mode = compat
+
+[flake8]
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+# tests/conftest.py
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def dnf_vars_dir(tmp_path, monkeypatch):
+    """Fixture to mock DNF_VARS_DIR to use a temp directory."""
+    dnf_path = tmp_path / "dnf" / "vars"
+    dnf_path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setattr("rlc.cloud_repos.main.DNF_VARS_DIR", dnf_path)
+    return dnf_path
+
+
+@pytest.fixture
+def marker(tmp_path, monkeypatch):
+    """Fixture to mock MARKERFILE to use a temp file."""
+    marker_path = tmp_path / ".configured"
+    monkeypatch.setattr("rlc.cloud_repos.main.MARKERFILE", str(marker_path))
+    yield marker_path
+
+
+@pytest.fixture
+def mirrors_file(tmp_path, monkeypatch):
+    """Fixture to create a temporary mirrors file."""
+    mirrors_path = tmp_path / "mirrors.yaml"
+
+    # Copy the content from the package data to mirrors.yaml
+    source_path = Path(__file__).parent.parent / "data/ciq-mirrors.yaml"
+    shutil.copy(source_path, mirrors_path)
+
+    monkeypatch.setattr("rlc.cloud_repos.main.DEFAULT_MIRROR_PATH", mirrors_path)
+    yield mirrors_path
+
+
+# Add the src/ directory to the import path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))

--- a/tests/fixtures/azure.metadata.yaml
+++ b/tests/fixtures/azure.metadata.yaml
@@ -1,0 +1,237 @@
+# Sources:
+#
+# https://learn.microsoft.com/en-us/azure/reliability/cross-region-replication-azure#azure-paired-regions
+# https://learn.microsoft.com/en-us/azure/reliability/availability-zones-service-support
+
+Regions:
+  - name: eastus
+    registry_georeplications_available: true
+    zone_redundancy_available: true
+    display_name: East US
+    # Official pair is westus but we use westus2 for now since we aren't built out in westus
+    regional_pair: westus2
+  - name: westus2
+    registry_georeplications_available: true
+    zone_redundancy_available: true
+    display_name: West US 2
+    # Official pair is westcentralus but we use eastus for now since we aren't built out in westcentralus
+    regional_pair: eastus
+  - name: northeurope
+    registry_georeplications_available: true
+    zone_redundancy_available: true
+    display_name: North Europe
+    # Official pair is westeurope but we use southeastasia for now since we aren't built out in westeurope
+    regional_pair: southeastasia
+  - name: southeastasia
+    registry_georeplications_available: true
+    zone_redundancy_available: true
+    container_apps_zone_redundancy_available: false
+    display_name: Southeast Asia
+    # Official pair is eastasia but we use northeurope for now since we aren't built out in eastasia
+    regional_pair: northeurope
+  - name: australiaeast
+    registry_georeplications_available: true
+    zone_redundancy_available: true
+    display_name: Australia East
+    # Official pair is australiasoutheast but we use southeastasia for now since we aren't built out in australiasoutheast
+    regional_pair: southeastasia
+  # - name: australiacentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Australia Central
+  #   regional_pair: australiacentral2
+  # - name: brazilsouth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Brazil South
+  #   regional_pair: southcentralus
+  # # brazilsoutheast Not enabled by default, need to open a ticket
+  # - name: brazilsoutheast
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Brazil Southeast
+  #   regional_pair: brazilsouth
+  # - name: canadacentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Canada Central
+  #   regional_pair: canadaeast
+  # - name: francecentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: France Central
+  #   regional_pair: francesouth
+  # - name: germanywestcentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Germany West Central
+  #   regional_pair: germanynorth
+  # - name: centralindia
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Central India
+  #   regional_pair: southindia
+  # - name: westindia
+  #   registry_georeplications_available: false
+  #   zone_redundancy_available: false
+  #   display_name: West India
+  #   regional_pair: southindia
+  # - name: japaneast
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Japan East
+  #   regional_pair: japanwest
+  # - name: koreacentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Korea Central
+  #   regional_pair: koreasouth
+  # - name: norwayeast
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Norway West
+  #   regional_pair: norwayeast
+  # - name: southafricanorth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: South Africa North
+  #   regional_pair: southafricawest
+  # - name: swedencentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Sweden Central
+  #   regional_pair: swedensouth
+  # - name: switzerlandnorth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Switzerland North
+  #   regional_pair: switzerlandwest
+  # - name: ukwest
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: UK West
+  #   regional_pair: uksouth
+  # - name: eastus2
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: East US 2
+  #   regional_pair: centralus
+  # - name: northcentralus
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: North Central US
+  #   regional_pair: southcentralus
+  # - name: uaenorth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: UAE North
+  #   regional_pair: uaecentral
+
+# Regions in the "pair" column that we are not targeting for initial launch
+
+  # - name: australiasoutheast
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Australia Southeast
+  #   regional_pair: australiaeast
+  # # australiacentral2 Not enabled by default, need to open a ticket
+  # - name: australiacentral2
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Australia Central 2
+  #   regional_pair: australiacentral
+  # - name: southcentralus
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: South Central US
+  #   regional_pair: brazilsouth
+  # - name: canadaeast
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Canada East
+  #   regional_pair: canadacentral
+  # - name: westeurope
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: West Europe
+  #   regional_pair: northeurope
+  # # francesouth Not enabled by default, need to open a ticket
+  # - name: francesouth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: France South
+  #   regional_pair: francecentral
+  # # germanynorth Not enabled by default, need to open a ticket
+  # - name: germanynorth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Germany North
+  #   regional_pair: germanywestcentral
+  # - name: southindia
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: South India
+  #   regional_pair: centralindia
+  # - name: japanwest
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false # (technically available, but requires contacting sales team to find out about availability)
+  #   display_name: Japan West
+  #   regional_pair: japaneast
+  # # koreasouth Not enabled by default, need to open a ticket
+  # - name: koreasouth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Korea South
+  #   regional_pair: koreacentral
+  # # norwaywest Not enabled by default, need to open a ticket
+  # - name: norwaywest
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Norway West
+  #   regional_pair: norwayeast
+  # # southafricawest Not enabled by default, need to open a ticket
+  # - name: southafricawest
+  #   registry_georeplications_available: true
+  #   registry_georeplications_available: false
+  #   zone_redundancy_available: false
+  #   display_name: South Africa West
+  #   regional_pair: southafricanorth
+  # # swedensouth Not enabled by default, need to open a ticket
+  # - name: swedensouth
+  #   registry_georeplications_available: true
+  #   registry_georeplications_available: false
+  #   zone_redundancy_available: false
+  #   display_name: Sweden South
+  #   regional_pair: swedencentral
+  # # switzerlandwest Not enabled by default, need to open a ticket
+  # - name: switzerlandwest
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: Switzerland West
+  #   regional_pair: switzerlandnorth
+  # - name: uksouth
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: UK South
+  #   regional_pair: ukwest
+  # - name: westus
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: West US
+  #   regional_pair: eastus
+  # - name: centralus
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: true
+  #   display_name: Central US
+  #   regional_pair: eastus2
+  # - name: westcentralus
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: West Central US
+  #   regional_pair: westus2
+  # # uaecentral Not enabled by default, need to open a ticket
+  # - name: uaecentral
+  #   registry_georeplications_available: true
+  #   zone_redundancy_available: false
+  #   display_name: UAE Central
+  #   regional_pair: uaenorth

--- a/tests/framework/test_azure_mirrors.py
+++ b/tests/framework/test_azure_mirrors.py
@@ -1,0 +1,201 @@
+from pathlib import Path
+
+import pytest
+import yaml
+
+from rlc_cloud_repos_framework import azure_mirrors as am
+
+FIXTURES_DIR = Path(__file__).parent.parent / "fixtures"
+
+
+def test_load_yaml_file(mirrors_file):
+    data = am.load_yaml_file(str(mirrors_file))
+    assert isinstance(data, dict)
+    assert "azure" in data
+
+
+def test_extract_active_regions():
+    metadata = {
+        "Regions": [
+            {"name": "eastus", "regional_pair": "westus2"},
+            {"name": "westus2", "regional_pair": "eastus"},
+            None,  # Test handling of None entries
+            {"wrongkey": "should be skipped"},  # Test handling of invalid entries
+        ]
+    }
+    regions = am.extract_active_regions(metadata)
+    assert len(regions) == 2
+    assert regions[0]["name"] == "eastus"
+    assert regions[0]["regional_pair"] == "westus2"
+    assert regions[1]["name"] == "westus2"
+    assert regions[1]["regional_pair"] == "eastus"
+
+
+def test_generate_mirror_urls():
+    regions = [
+        {"name": "eastus", "regional_pair": "westus2"},
+        {"name": "westus2", "regional_pair": "eastus"},
+    ]
+    mirrors = am.generate_mirror_urls(regions)
+
+    assert "eastus" in mirrors
+    assert mirrors["eastus"]["primary"] == "https://depot.eastus.prod.azure.ciq.com"
+    assert mirrors["eastus"]["backup"] == "https://depot.westus2.prod.azure.ciq.com"
+
+    assert "westus2" in mirrors
+    assert mirrors["westus2"]["primary"] == "https://depot.westus2.prod.azure.ciq.com"
+    assert mirrors["westus2"]["backup"] == "https://depot.eastus.prod.azure.ciq.com"
+
+
+def test_transform_azure_mirrors(tmp_path):
+    # Create temporary test files
+    metadata_file = tmp_path / "test_metadata.yaml"
+    mirrors_file = tmp_path / "test_mirrors.yaml"
+    output_file = tmp_path / "test_output.yaml"
+
+    # Write test data
+    metadata = {
+        "Regions": [
+            {"name": "eastus", "regional_pair": "westus2"},
+            {"name": "westus2", "regional_pair": "eastus"},
+        ]
+    }
+    existing_mirrors = {
+        "azure": {"default": {"primary": "https://depot.eastus.prod.azure.ciq.com"}}
+    }
+
+    with open(metadata_file, "w") as f:
+        yaml.dump(metadata, f)
+    with open(mirrors_file, "w") as f:
+        yaml.dump(existing_mirrors, f)
+
+    # Run transformation
+    result = am.transform_azure_mirrors(
+        str(metadata_file), str(mirrors_file), str(output_file)
+    )
+
+    # Verify results
+    assert "azure" in result
+    assert "default" in result["azure"]
+    assert "eastus" in result["azure"]
+    assert "westus2" in result["azure"]
+    assert (
+        result["azure"]["eastus"]["primary"]
+        == "https://depot.eastus.prod.azure.ciq.com"
+    )
+    assert (
+        result["azure"]["eastus"]["backup"]
+        == "https://depot.westus2.prod.azure.ciq.com"
+    )
+
+
+def test_transform_azure_mirrors_error_handling():
+    with pytest.raises(FileNotFoundError):
+        am.transform_azure_mirrors(
+            "nonexistent_metadata.yaml", "nonexistent_mirrors.yaml"
+        )
+
+
+def test_parse_args_defaults():
+    """Test parse_args with default arguments."""
+    args = am.parse_args([])
+    assert args.metadata == "azure.metadata.yaml"
+    assert args.mirrors == "src/rlc_cloud_repos/data/ciq-mirrors.yaml"
+    assert args.output is None
+    assert not args.verify
+
+
+def test_parse_args_with_values():
+    """Test parse_args with custom values."""
+    args = am.parse_args(
+        [
+            "--metadata",
+            "custom.yaml",
+            "--mirrors",
+            "mirrors.yaml",
+            "--output",
+            "out.yaml",
+            "--verify",
+        ]
+    )
+    assert args.metadata == "custom.yaml"
+    assert args.mirrors == "mirrors.yaml"
+    assert args.output == "out.yaml"
+    assert args.verify
+
+
+def test_main_success(tmp_path):
+    """Test main function with valid files."""
+    metadata_file = tmp_path / "metadata.yaml"
+    mirrors_file = tmp_path / "mirrors.yaml"
+
+    # Create test files
+    metadata = {"Regions": [{"name": "eastus", "regional_pair": "westus2"}]}
+    mirrors = {
+        "azure": {"default": {"primary": "https://depot.eastus.prod.azure.ciq.com"}}
+    }
+
+    with open(metadata_file, "w") as f:
+        yaml.dump(metadata, f)
+    with open(mirrors_file, "w") as f:
+        yaml.dump(mirrors, f)
+
+    result = am.main(["--metadata", str(metadata_file), "--mirrors", str(mirrors_file)])
+    assert result == 0
+
+
+def test_main_verify_mode(tmp_path):
+    """Test main function in verify mode."""
+    metadata_file = tmp_path / "metadata.yaml"
+    mirrors_file = tmp_path / "mirrors.yaml"
+
+    # Create test files with different content
+    metadata = {"Regions": [{"name": "eastus", "regional_pair": "westus2"}]}
+    mirrors = {"azure": {"default": {"primary": "https://old.url.com"}}}
+
+    with open(metadata_file, "w") as f:
+        yaml.dump(metadata, f)
+    with open(mirrors_file, "w") as f:
+        yaml.dump(mirrors, f)
+
+    result = am.main(
+        ["--metadata", str(metadata_file), "--mirrors", str(mirrors_file), "--verify"]
+    )
+    assert result == 1
+
+
+def test_main_verify_mode_no_change(tmp_path):
+    """Test main function in verify mode."""
+    metadata_file = tmp_path / "metadata.yaml"
+    mirrors_file = tmp_path / "mirrors.yaml"
+
+    # Create test files with different content
+    metadata = {"Regions": [{"name": "eastus", "regional_pair": "westus2"}]}
+    mirrors = {
+        "azure": {
+            "eastus": {
+                "primary": "https://depot.eastus.prod.azure.ciq.com",
+                "backup": "https://depot.westus2.prod.azure.ciq.com",
+            },
+            "default": {
+                "primary": "https://depot.eastus.prod.azure.ciq.com",
+                "backup": "https://depot.westus2.prod.azure.ciq.com",
+            },
+        }
+    }
+
+    with open(metadata_file, "w") as f:
+        yaml.dump(metadata, f)
+    with open(mirrors_file, "w") as f:
+        yaml.dump(mirrors, f)
+
+    result = am.main(
+        ["--metadata", str(metadata_file), "--mirrors", str(mirrors_file), "--verify"]
+    )
+    assert result == 0
+
+
+def test_main_error_handling():
+    """Test main function with invalid files."""
+    result = am.main(["--metadata", "nonexistent.yaml"])
+    assert result == 1

--- a/tests/test_cloud_metadata.py
+++ b/tests/test_cloud_metadata.py
@@ -1,0 +1,146 @@
+# tests/test_cloud_metadata_suite.py
+"""
+Test Suite: Cloud Metadata Detection & Mirror Selection
+
+This module validates:
+- Cloud provider & region extraction from cloud-init metadata
+- Mirror URL selection based on provider/region
+- YUM repo config generation
+"""
+
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from rlc.cloud_repos.cloud_metadata import get_cloud_metadata
+from rlc.cloud_repos.dnf_vars import ensure_all_dnf_vars
+from rlc.cloud_repos.log_utils import log_and_print
+from rlc.cloud_repos.repo_config import load_mirror_map, select_mirror
+
+MIRROR_FIXTURES = Path(__file__).parent.parent / "data/ciq-mirrors.yaml"
+
+
+@pytest.mark.parametrize(
+    "expected_provider,expected_region",
+    [
+        ("aws", "us-west-2"),
+        ("azure", "eastus"),
+        ("gcp", "us-central1"),
+        ("oracle", "us-ashburn-1"),
+        ("unknown", "fallback-region"),
+    ],
+)
+def test_cloud_metadata_and_mirror(
+    monkeypatch, mirrors_file, expected_provider, expected_region
+):
+    """
+    Validates that cloud metadata and mirror resolution behave as expected.
+    """
+
+    def fake_check_output(cmd, text=True):
+        if "cloud_name" in cmd:
+            return expected_provider
+        elif "region" in cmd:
+            return expected_region
+
+    monkeypatch.setattr(
+        "rlc.cloud_repos.cloud_metadata.subprocess.check_output", fake_check_output
+    )
+    # Use setattr to patch the default path constant directly
+    mock_mirror_path = str(mirrors_file)
+    # Clear potential env var override to ensure setattr is effective
+    metadata = get_cloud_metadata()
+    assert metadata["provider"] == expected_provider
+    assert metadata["region"] == expected_region
+
+    mirror_map = load_mirror_map(mock_mirror_path)
+    primary, backup = select_mirror(metadata, mirror_map)
+    assert primary.startswith("https://")
+    assert isinstance(backup, str)
+
+
+def test_dnf_vars_creation_and_backup(monkeypatch, mirrors_file, tmp_path):
+    var_dir = tmp_path / "dnf_vars"
+    var_dir.mkdir()
+    (var_dir / "baseurl1").write_text("original-value")
+
+    # Use setattr to patch the default path constant directly
+    mock_mirror_path = str(mirrors_file)
+
+    monkeypatch.setattr(
+        "rlc.cloud_repos.cloud_metadata.subprocess.check_output",
+        lambda cmd, text=True: {"cloud_name": "aws", "region": "us-west-2"}[cmd[-1]],
+    )
+
+    metadata = get_cloud_metadata()
+    mirror_map = load_mirror_map(mock_mirror_path)
+    primary, backup = select_mirror(metadata, mirror_map)
+    ensure_all_dnf_vars(var_dir, primary, backup)
+
+    for var in ["baseurl1", "baseurl2"]:
+        assert (var_dir / var).exists()
+
+    assert (var_dir / "baseurl1.bak").exists()
+
+
+def test_cloud_metadata_returns_dict(monkeypatch):
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        lambda cmd, text=True: "aws" if "cloud_name" in cmd else "us-west-2",
+    )
+    result = get_cloud_metadata()
+    assert isinstance(result, dict)
+    assert result["provider"] == "aws"
+    assert result["region"] == "us-west-2"
+
+
+def test_cloud_metadata_handles_subprocess_error(monkeypatch):
+    """Test that get_cloud_metadata properly handles subprocess errors."""
+
+    side_effect = subprocess.CalledProcessError(1, "cloud-init", "test error")
+
+    monkeypatch.setattr("subprocess.check_output", MagicMock(side_effect=side_effect))
+
+    with pytest.raises(
+        RuntimeError, match="cloud-init must be available and functional"
+    ):
+        get_cloud_metadata()
+
+
+def test_logger_fallback_and_log_and_print(monkeypatch):
+    mock_logger = MagicMock()
+    monkeypatch.setattr("rlc.cloud_repos.log_utils.logger", mock_logger)
+    log_and_print("Test log output", level="info")
+    mock_logger.info.assert_called_with("Test log output")
+    log_and_print("Test log output", level="info")
+    mock_logger.info.assert_called_with("Test log output")
+
+
+def test_metadata_file_for_missing_values(mirrors_file):
+    mirror_map = load_mirror_map(str(mirrors_file))
+
+    # The mirror map must provide a default provider section with primary and backup values
+    assert "default" in mirror_map, "No default section found in the mirror map"
+    assert "primary" in mirror_map["default"], "No primary URL found in default section"
+    assert "backup" in mirror_map["default"], "No backup URL found in default section"
+    mirror_map.pop("default")
+
+    for key, value in mirror_map.items():
+        # Each provider must provide a default with primary and backup values
+        assert "default" in value, f"No default section found in provider '{key}'"
+        assert (
+            "primary" in value["default"]
+        ), f"No primary URL found in default section of provider '{key}'"
+        assert (
+            "backup" in value["default"]
+        ), f"No backup URL found in default section of provider '{key}'"
+        value.pop("default")
+        for region, r_map in value.items():
+            assert (
+                "primary" in r_map
+            ), f"No primary URL found in region '{region}' of provider '{key}'"
+            assert (
+                "backup" in r_map
+            ), f"No backup URL found in region '{region}' of provider '{key}'"

--- a/tests/test_dnf_vars.py
+++ b/tests/test_dnf_vars.py
@@ -1,0 +1,114 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from rlc.cloud_repos.dnf_vars import BACKUP_SUFFIX, _write_dnf_var, ensure_all_dnf_vars
+
+
+@pytest.fixture
+def dnf_dir(tmp_path):
+    """Create a temporary DNF vars directory"""
+    vars_dir = tmp_path / "dnf" / "vars"
+    vars_dir.mkdir(parents=True)
+    yield vars_dir
+
+
+def test_write_dnf_var_new_file(dnf_dir):
+    """Test writing a DNF var to a new file"""
+    _write_dnf_var(dnf_dir, "test", "value")
+    path = dnf_dir / "test"
+    assert path.exists()
+    assert path.read_text().strip() == "value"
+
+
+def test_write_dnf_var_existing_same_value(dnf_dir):
+    """Test writing a DNF var when file exists with same value"""
+    path = dnf_dir / "test"
+    path.write_text("value\n")
+
+    _write_dnf_var(dnf_dir, "test", "value")
+    assert path.exists()
+    assert not (path.parent / f"test{BACKUP_SUFFIX}").exists()
+    assert path.read_text().strip() == "value"
+
+
+def test_write_dnf_var_existing_different_value(dnf_dir):
+    """Test writing a DNF var when file exists with different value"""
+    path = dnf_dir / "test"
+    path.write_text("old_value\n")
+
+    _write_dnf_var(dnf_dir, "test", "new_value")
+    assert path.exists()
+    assert (path.parent / f"test{BACKUP_SUFFIX}").exists()
+    assert path.read_text().strip() == "new_value"
+    assert (path.parent / f"test{BACKUP_SUFFIX}").read_text().strip() == "old_value"
+
+
+def test_ensure_all_dnf_vars(dnf_dir):
+    """Test ensuring all DNF vars are set"""
+    primary = "https://primary.mirror"
+    backup = "https://backup.mirror"
+
+    ensure_all_dnf_vars(dnf_dir, primary, backup)
+
+    assert (dnf_dir / "baseurl1").read_text().strip() == primary
+    assert (dnf_dir / "baseurl2").read_text().strip() == backup
+
+
+def test_ensure_all_dnf_vars_idempotent(dnf_dir):
+    """Test ensuring all DNF vars doesn't create backups if values unchanged"""
+    primary = "https://primary.mirror"
+    backup = "https://backup.mirror"
+
+    # First call
+    ensure_all_dnf_vars(dnf_dir, primary, backup)
+    # Second call
+    ensure_all_dnf_vars(dnf_dir, primary, backup)
+
+    assert not (dnf_dir / f"baseurl1{BACKUP_SUFFIX}").exists()
+    assert not (dnf_dir / f"baseurl2{BACKUP_SUFFIX}").exists()
+
+
+def test_ensure_all_dnf_vars_changes(dnf_dir):
+    """Test ensuring all DNF vars creates backups when values change"""
+    # First call
+    ensure_all_dnf_vars(dnf_dir, "old_primary", "old_backup")
+    # Second call with different values
+    ensure_all_dnf_vars(dnf_dir, "new_primary", "new_backup")
+
+    assert (dnf_dir / f"baseurl1{BACKUP_SUFFIX}").exists()
+    assert (dnf_dir / f"baseurl2{BACKUP_SUFFIX}").exists()
+    assert (dnf_dir / f"baseurl1{BACKUP_SUFFIX}").read_text().strip() == "old_primary"
+    assert (dnf_dir / f"baseurl2{BACKUP_SUFFIX}").read_text().strip() == "old_backup"
+
+
+def test_write_dnf_var_non_writable_dir_non_existent_file(monkeypatch, dnf_dir, caplog):
+    """Test writing DNF var to a non-writable directory."""
+    # Make directory "read-only"
+    monkeypatch.setattr(
+        "pathlib.Path.write_text",
+        MagicMock(side_effect=PermissionError("Permission denied")),
+    )
+
+    _write_dnf_var(dnf_dir, "test", "value")
+
+    # Verify error was logged
+    assert "Cannot write to DNF var 'test'" in caplog.text
+    assert "Permission denied" in caplog.text
+
+
+def test_write_dnf_var_non_writable_dir_pre_existing_file(monkeypatch, dnf_dir, caplog):
+    """Test writing DNF var to a non-writable directory."""
+    # Make directory read-only
+    _write_dnf_var(dnf_dir, "test", "pre-value")
+
+    monkeypatch.setattr(
+        "pathlib.Path.rename",
+        MagicMock(side_effect=PermissionError("Permission denied")),
+    )
+
+    _write_dnf_var(dnf_dir, "test", "value")
+
+    # Verify error was logged
+    assert "Cannot backup DNF var 'test'" in caplog.text
+    assert "Permission denied" in caplog.text

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,82 @@
+from pathlib import Path
+
+import pytest
+
+from rlc.cloud_repos.main import _configure_repos, main, parse_args
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+@pytest.fixture(autouse=True)
+def mock_get_cloud_metadata(monkeypatch, request):
+    if "test_cloud_metadata_suite" not in request.node.nodeid:
+        monkeypatch.setattr(
+            "rlc.cloud_repos.main.get_cloud_metadata",
+            lambda: {"provider": "mock", "region": "mock-region"},
+        )
+
+
+def test_parse_args_default():
+    """Test parse_args with default arguments."""
+    args = parse_args([])
+    assert args.mirror_file is None
+    assert not args.force
+
+
+def test_parse_args_with_values():
+    """Test parse_args with specific values."""
+    args = parse_args(["--mirror-file", "test.yaml", "--force"])
+    assert args.mirror_file == "test.yaml"
+    assert args.force
+
+
+def test_main_with_force_flag(tmp_path, dnf_vars_dir, marker, mirrors_file):
+    """Test main function with force flag bypasses marker check."""
+    marker.touch()
+
+    result = main(["--force"])
+    assert result == 0
+
+
+def test_main_respects_marker_file(tmp_path, marker):
+    """Test main respects existing marker file."""
+    marker.touch()
+
+    result = main([])
+    assert result == 0
+
+
+def test_main_creates_marker_file(tmp_path, dnf_vars_dir, marker, mirrors_file):
+    """Test main creates marker file after successful run."""
+    result = main([])
+    assert result == 0
+    assert marker.exists()
+
+
+def test_main_with_custom_mirror_file(tmp_path, dnf_vars_dir, marker, mirrors_file):
+    """Test main with custom mirror file path."""
+    result = main(["--mirror-file", str(mirrors_file)])
+    assert result == 0
+
+
+def test_main_handles_configuration_error(tmp_path, monkeypatch):
+    """Test main handles configuration errors gracefully."""
+    monkeypatch.setattr(
+        "rlc.cloud_repos.main._configure_repos",
+        lambda x: (_ for _ in ()).throw(Exception("Test error")),
+    )
+    result = main(["--force"])
+    assert result == 1
+
+
+def test_configure_repos_writes_touchfile(tmp_path, dnf_vars_dir, marker, mirrors_file):
+    """Test _configure_repos writes marker file."""
+    _configure_repos(str(mirrors_file))
+    assert marker.exists()
+    assert "Configured on" in marker.read_text()
+
+
+def test_configure_repos_invalid_mirror_file():
+    """Test _configure_repos with invalid mirror file."""
+    with pytest.raises(Exception):
+        _configure_repos("nonexistent.yaml")

--- a/tests/test_repo_config.py
+++ b/tests/test_repo_config.py
@@ -1,0 +1,78 @@
+import pytest
+
+from rlc.cloud_repos.repo_config import load_mirror_map, select_mirror
+
+
+def test_load_mirror_map_success(mirrors_file):
+    """Test successful loading of mirror map."""
+    mirror_map = load_mirror_map(str(mirrors_file))
+    assert isinstance(mirror_map, dict)
+    assert "azure" in mirror_map
+    assert "default" in mirror_map
+
+
+def test_load_mirror_map_file_not_found():
+    """Test load_mirror_map with nonexistent file."""
+    with pytest.raises(FileNotFoundError):
+        load_mirror_map("nonexistent.yaml")
+
+
+def test_load_mirror_map_invalid_yaml(tmp_path):
+    """Test load_mirror_map with invalid YAML."""
+    invalid_yaml = tmp_path / "invalid.yaml"
+    invalid_yaml.write_text("{ invalid: yaml: content")
+    with pytest.raises(ValueError):
+        load_mirror_map(str(invalid_yaml))
+
+
+@pytest.mark.parametrize(
+    "provider,region",
+    [
+        ("azure", "eastus"),
+        ("azure", "westus2"),
+        ("azure", "nonexistent-region"),
+        ("gcp", "us-central1"),
+        ("oracle", "us-ashburn-1"),
+        ("unknown-provider", "unknown-region"),
+    ],
+)
+def test_select_mirror_returns_non_empty_urls(mirrors_file, provider, region):
+    """Test select_mirror always returns two non-empty URLs."""
+    mirror_map = load_mirror_map(str(mirrors_file))
+
+    primary, backup = select_mirror(
+        {"provider": provider, "region": region}, mirror_map
+    )
+
+    assert isinstance(primary, str)
+    assert isinstance(backup, str)
+    assert primary != ""
+    assert primary.startswith("https://")
+
+
+def test_select_mirror_provider_fallback(mirrors_file):
+    """Test select_mirror falls back to provider default."""
+    mirror_map = load_mirror_map(str(mirrors_file))
+
+    primary, backup = select_mirror(
+        {"provider": "azure", "region": "unknown"}, mirror_map
+    )
+    assert primary == "https://depot.eastus.prod.azure.ciq.com"
+
+
+def test_select_mirror_global_fallback(mirrors_file):
+    """Test select_mirror falls back to global default."""
+    mirror_map = load_mirror_map(str(mirrors_file))
+
+    primary, backup = select_mirror(
+        {"provider": "unknown", "region": "unknown"}, mirror_map
+    )
+    assert primary == "https://depot.eastus.prod.azure.ciq.com"
+
+
+def test_select_mirror_no_fallback():
+    """Test select_mirror raises error when no fallback exists."""
+    mirror_map = {"azure": {"eastus": {"primary": "url"}}}  # No default entry
+
+    with pytest.raises(ValueError):
+        select_mirror({"provider": "unknown", "region": "unknown"}, mirror_map)


### PR DESCRIPTION
A tool to configure DNF vars for baseurl1 and baseurl2 for the closest available CIQ hosted RLC mirrors. Depends on cloud-init for locality information.

- Added setup configuration for the framework in setup.cfg.
- Created setup.py for package installation.
- Introduced RPM spec file for building the Python package.
- Implemented test fixtures and test cases for cloud metadata and mirror selection.
- Developed DNF variable management functions with corresponding tests.
- Added main functionality for configuring repositories and handling command-line arguments.
- Included YAML files for Azure metadata and mirror configurations.
- Established logging utilities for better error handling and reporting.
- Ensured all tests are passing and cover various edge cases.

Authors: Joel Hanger, Joseph Tate